### PR TITLE
Downsample consistently, improve writing UX, and change how OCR'd text is displayed

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 <div id="controls">
 	<button id="video-control">Start</button>
 </div>
-<div id="instructions">Press the <strong>Start</strong> button to start reading in camera data. Then either click your mouse or (if on touch device) touch within the box above to begin writing. When you're done, click <strong>Stop</strong>, and your writing will attempt to be transcribed below.</div>
+<div id="instructions">Press the <strong>Start</strong> button to start reading in camera data. Then either click your mouse or (if on touch device) touch within the box above to begin writing. Click again or lift your finger to stop writing and move the reticle. When you're done, click <strong>Stop</strong>, and your writing will attempt to be transcribed below.</div>
 <div id="text-output"></div>
 
 <aside id="about">

--- a/index.html
+++ b/index.html
@@ -14,10 +14,12 @@
 </header>
 <div id="glyph-container">
 	<canvas id="glyph" width="480" height="320">Your browser does not support HTML5</canvas>
+	<canvas id="reticle" width="480" height="320"></canvas>
 </div>
 <div id="controls">
 	<button id="video-control">Start</button>
 </div>
+<div id="instructions">Press the <strong>Start</strong> button to start reading in camera data. Then either click your mouse or (if on touch device) touch within the box above to begin writing. When you're done, click <strong>Stop</strong>, and your writing will attempt to be transcribed below.</div>
 <div id="text-output"></div>
 
 <aside id="about">

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <header>
-	<h1>Spellcast, v0.1.0</h1>
+	<h1>Spellcast, v0.1.1</h1>
 </header>
 <div id="glyph-container">
 	<canvas id="glyph" width="480" height="320">Your browser does not support HTML5</canvas>

--- a/public/javascripts/classes/CastConverter.js
+++ b/public/javascripts/classes/CastConverter.js
@@ -25,8 +25,9 @@ export default function CastConverter(analyzer, writer, reader) {
  * Converts the image into vectors and passes them to the writer
  * 
  * @param  {ImageData} imageData from input context for video
+ * @param  {Boolean} whether should be writing or just moving reticle
  */
-CastConverter.prototype.convertFrame = function(imageData) {
+CastConverter.prototype.convertFrame = function(imageData, recording) {
 	this.analyzer.parse(imageData);
-	this.writer.write(this.analyzer.getAverageVector());
+	this.writer.write(this.analyzer.getAverageVector(), recording);
 };

--- a/public/javascripts/classes/GlyphWriter.js
+++ b/public/javascripts/classes/GlyphWriter.js
@@ -3,10 +3,13 @@
  * 
  * @param {canvas} outputCanvas
  */
-export default function GlyphWriter(outputCanvas) {
+export default function GlyphWriter(outputCanvas, reticleCanvas) {
 	this.outputCanvas = outputCanvas;
 	this.outputContext = outputCanvas.getContext('2d', { alpha: "false" });
 	this.outputContext.strokeStyle = "red";
+	this.reticleCanvas = reticleCanvas;
+	this.reticleContext = reticleCanvas.getContext('2d', { alpha: "false" });
+	this.reticleContext.strokeStyle = "black";
 	this.totalWidth = outputCanvas.width;
 	this.totalHeight = outputCanvas.height;
 	this.currentPosition = [ 
@@ -19,8 +22,9 @@ export default function GlyphWriter(outputCanvas) {
  * Write to the outputContext using the given vector
  *
  * @param  {Array} vector an x and y vector
+ * @param  {Boolean} whether actually drawing to context or just moving reticle
  */
-GlyphWriter.prototype.write = function(vector) {
+GlyphWriter.prototype.write = function(vector, recording) {
 	// Get current position and subtract vector 
 	// (since the vectors are inverted for the image)
 	let [startWidth, startHeight] = this.currentPosition;
@@ -42,12 +46,42 @@ GlyphWriter.prototype.write = function(vector) {
 		this.currentPosition[1] = 0;
 	}
 
-	// Draw path
-	// TODO: replace drawing with offscreen canvas for optimization
-	// See https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Optimizing_canvas
-	// Or possibly https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas
-	this.outputContext.beginPath();
-	this.outputContext.moveTo(startWidth, startHeight);
-	this.outputContext.lineTo(this.currentPosition[0], this.currentPosition[1]);
-	this.outputContext.stroke();
+	if (recording) {
+		// Draw path
+		// TODO: replace drawing with offscreen canvas for optimization
+		// See https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Optimizing_canvas
+		// Or possibly https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas
+		this.outputContext.beginPath();
+		this.outputContext.moveTo(startWidth, startHeight);
+		this.outputContext.lineTo(this.currentPosition[0], this.currentPosition[1]);
+		this.outputContext.stroke();		
+	}
+
+	this.drawReticle(recording);
 };
+
+/**
+ * Draw the reticle on the reticle canvas
+ * 
+ * @param  {Boolean} recording Whether to draw recording reticle or rest reticle
+ */
+GlyphWriter.prototype.drawReticle = function(recording) {
+	this.reticleContext.clearRect(0, 0, this.totalWidth, this.totalHeight)
+	this.reticleContext.beginPath();
+
+	if (recording) {
+		// Draw a circle around the point
+		this.reticleContext.arc(this.currentPosition[0], this.currentPosition[1], 5, 0, 2 * Math.PI);
+
+	} else {
+		// Draw a horizontal line
+		this.reticleContext.moveTo(this.currentPosition[0]-5, this.currentPosition[1]);
+		this.reticleContext.lineTo(this.currentPosition[0]+5, this.currentPosition[1]);
+
+		// And a vertical line
+		this.reticleContext.moveTo(this.currentPosition[0], this.currentPosition[1]-5);
+		this.reticleContext.lineTo(this.currentPosition[0], this.currentPosition[1]+5);
+	}
+
+	this.reticleContext.stroke();
+}

--- a/public/javascripts/classes/GlyphWriter.js
+++ b/public/javascripts/classes/GlyphWriter.js
@@ -28,6 +28,20 @@ GlyphWriter.prototype.write = function(vector) {
 	this.currentPosition[0] = startWidth - deltaX;
 	this.currentPosition[1] = startHeight - deltaY;
 
+	// Prevent position from moving past frame
+	if (this.currentPosition[0] > this.totalWidth) {
+		this.currentPosition[0] = this.totalWidth;
+	}
+	if (this.currentPosition[0] < 0) {
+		this.currentPosition[0] = 0;
+	}
+	if (this.currentPosition[1] > this.totalHeight) {
+		this.currentPosition[1] = this.totalHeight;
+	}
+	if (this.currentPosition[1] < 0) {
+		this.currentPosition[1] = 0;
+	}
+
 	// Draw path
 	// TODO: replace drawing with offscreen canvas for optimization
 	// See https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Optimizing_canvas

--- a/public/javascripts/classes/OptFlowAnalyzer.js
+++ b/public/javascripts/classes/OptFlowAnalyzer.js
@@ -5,7 +5,7 @@ export default function OptFlowAnalyzer() {
 	 * 
 	 * @type {Number}
 	 */
-	this.max_iterations = 30;
+	this.max_iterations = 15;
 
 	/**
 	 * From jsfeat:
@@ -13,7 +13,7 @@ export default function OptFlowAnalyzer() {
 	 * 
 	 * @type {Number}
 	 */
-	this.win_size = 20;
+	this.win_size = 15;
 
 	/**
 	 * From jsfeat:

--- a/public/javascripts/classes/Processor.js
+++ b/public/javascripts/classes/Processor.js
@@ -17,6 +17,14 @@ export default function Processor(video, converter, width, height) {
 	 * ID for requestAnimationFrame
 	 */
 	this.requestId;
+
+	/**
+	 * Whether movements are currently being recorded on glyph or 
+	 * if reticle is simply moving.
+	 * 
+	 * @type {Boolean}
+	 */
+	this.recording = false;
 };
 
 /**
@@ -27,10 +35,15 @@ Processor.prototype.start = function() {
 	this.requestId = window.requestAnimationFrame(this.start.bind(this));
 	this.offscreenContext.drawImage(this.video, 0, 0, this.width, this.height);
 	let imageData = this.offscreenContext.getImageData(0, 0, this.width, this.height);
-	this.converter.convertFrame(imageData);
+	this.converter.convertFrame(imageData, this.recording);
 };
 
 Processor.prototype.stop = function() {
 	// TODO: canceling animation frame should maybe live in the purview of the Spellcast object
 	window.cancelAnimationFrame(this.requestId);
+}
+
+Processor.prototype.toggleRecording = function(event) {
+	this.recording = !this.recording;
+	event.preventDefault();
 }

--- a/public/javascripts/classes/Spellcast.js
+++ b/public/javascripts/classes/Spellcast.js
@@ -217,15 +217,16 @@ Spellcast.prototype.transcribeGlyph = function() {
 
 		if (result.symbols[0]) {
 
-			// TODO: improve how we're parsing the text. We might not want the "first" symbol in the image...
-			let firstSymbol = result.symbols[0].text;
-			
+			// TODO: improve how we're parsing the text. We might want to provide all the symbols 
+			// in the image and allow the user to select the "right" one
+			// let symbols = result.symbols;
+
 			// Put it on the page
-			let text = document.createTextNode(firstSymbol);
+			let text = document.createTextNode(result.text.trim());
 			this.textOutput.appendChild(text);
-			this.videoControl.innerHTML = "Reload page";	
+			this.videoControl.innerHTML = "Reload page";
 		} else {
-			this.videoControl.innerHTML = "Can't parse symbol, try again";
+			this.videoControl.innerHTML = "Can't parse symbol or text, try again";
 		}
 		
 		this.transcribing = false;

--- a/public/javascripts/classes/Spellcast.js
+++ b/public/javascripts/classes/Spellcast.js
@@ -23,6 +23,11 @@ export default function Spellcast() {
 	 * be written to.
 	 */
 	this.glyph;
+	
+	/**
+	 * The canvas element that tracks where the tip of the drawing is
+	 */
+	this.reticle;
 
 	/**
 	 * Currently capturing video
@@ -80,6 +85,7 @@ export default function Spellcast() {
 Spellcast.prototype.boot = function() {
 	this.videoControl = document.getElementById('video-control');
 	this.glyph = document.getElementById('glyph');
+	this.reticle = document.getElementById('reticle');
 	this.textOutput = document.getElementById('text-output');
 
 	// TODO: add handling for making this work on all mobile browsers
@@ -132,9 +138,14 @@ Spellcast.prototype.loadProcessorAndListeners = function() {
 	// Bind processor to video playback and begin playback
 	this.video.addEventListener('playing', processor.start.bind(processor), false);
 	this.video.addEventListener('ended', processor.stop.bind(processor), false);
-	this.video.addEventListener('pause', processor.stop.bind(processor), false);
+	this.video.addEventListener('pause', processor.stop.bind(processor), false);	
 	this.videoControl.addEventListener('click', this.toggleControl.bind(this), false);
 
+	// Bind touch or mouse events in glyph canvas to drawing 
+	this.reticle.addEventListener('touchstart', processor.toggleRecording.bind(processor), false);
+	this.reticle.addEventListener('touchend', processor.toggleRecording.bind(processor), false);
+	this.reticle.addEventListener('click', processor.toggleRecording.bind(processor), false);
+	
 	// Bind transcription event when video pauses
 	this.video.addEventListener('pause', this.transcribeGlyph.bind(this), false);	
 };
@@ -179,7 +190,7 @@ Spellcast.prototype.toggleControl = function() {
 Spellcast.prototype.generateVideoProcessor = function() {
 	let converter = new CastConverter(
 		new OptFlowAnalyzer().init(), 
-		new GlyphWriter(this.glyph)
+		new GlyphWriter(this.glyph, this.reticle)
 	);
 	return new Processor(
 		this.video, 

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -23,6 +23,11 @@ a {
 	width: 480px;
 }
 
+#instructions {
+	margin: 25px auto;
+	width: 480px;
+}
+
 #video-control {
 	width: 480px;
 	height: 80px;

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -20,7 +20,7 @@ a {
 
 #controls {
 	margin: 25px auto;
-	width: 500px;
+	width: 480px;
 }
 
 #video-control {
@@ -30,7 +30,10 @@ a {
 
 #glyph-container {
 	margin: 0 auto;
-    width: 500px;
+    width: 480px;
+    height: 320px;
+    position: relative;
+    border: solid 1px gray;
 }
 
 #about {
@@ -42,9 +45,7 @@ a {
 	margin: 13px auto;
 }
 
-#glyph {
-	border: solid gray 1px;
+#glyph, #reticle {
+	position: absolute;
 	margin: 0 auto;
-	width: 480px;
-	height: 320px;
 }

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -3,6 +3,7 @@
 </header>
 <div id="glyph-container">
 	<canvas id="glyph" width="480" height="320">Your browser does not support HTML5</canvas>
+	<canvas id="reticle" width="480" height="320"></canvas>
 </div>
 <div id="controls">
 	<button id="video-control">Start</button>

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -8,5 +8,5 @@
 <div id="controls">
 	<button id="video-control">Start</button>
 </div>
-<div id="instructions">Press the <strong>Start</strong> button to start reading in camera data. Then either click your mouse or (if on touch device) touch within the box above to begin writing. When you're done, click <strong>Stop</strong>, and your writing will attempt to be transcribed below.</div>
+<div id="instructions">Press the <strong>Start</strong> button to start reading in camera data. Then either click your mouse or (if on touch device) touch within the box above to begin writing. Click again or lift your finger to stop writing and move the reticle. When you're done, click <strong>Stop</strong>, and your writing will attempt to be transcribed below.</div>
 <div id="text-output"></div>

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -8,4 +8,5 @@
 <div id="controls">
 	<button id="video-control">Start</button>
 </div>
+<div id="instructions">Press the <strong>Start</strong> button to start reading in camera data. Then either click your mouse or (if on touch device) touch within the box above to begin writing. When you're done, click <strong>Stop</strong>, and your writing will attempt to be transcribed below.</div>
 <div id="text-output"></div>


### PR DESCRIPTION
This handles the following issues:
https://github.com/rtzm/spellcast/issues/19
https://github.com/rtzm/spellcast/issues/16
https://github.com/rtzm/spellcast/issues/20

However, more work can be done to make the drawing process a better UX and more intuitive. Also, introducing the reticle also introduces a lot more lag. The performance for this should be tweaked, possibly through an offscreen canvas or a stored image of some sort.